### PR TITLE
fix: restore d-pad and HUD routing broken by god-class refactor

### DIFF
--- a/app/src/main/java/com/github/ma1co/pmcademo/app/HudController.java
+++ b/app/src/main/java/com/github/ma1co/pmcademo/app/HudController.java
@@ -2,7 +2,7 @@ package com.github.ma1co.pmcademo.app;
 
 import android.content.Context;
 import android.graphics.Color;
-import android.graphics.Gravity;
+import android.view.Gravity;
 import android.graphics.Typeface;
 import android.os.Handler;
 import android.view.View;

--- a/app/src/main/java/com/github/ma1co/pmcademo/app/LensCalibrationController.java
+++ b/app/src/main/java/com/github/ma1co/pmcademo/app/LensCalibrationController.java
@@ -1,7 +1,7 @@
 package com.github.ma1co.pmcademo.app;
 
 import android.graphics.Color;
-import android.graphics.Gravity;
+import android.view.Gravity;
 import android.view.View;
 import android.widget.FrameLayout;
 import android.widget.TextView;

--- a/app/src/main/java/com/github/ma1co/pmcademo/app/MainActivity.java
+++ b/app/src/main/java/com/github/ma1co/pmcademo/app/MainActivity.java
@@ -126,7 +126,6 @@ public class MainActivity extends Activity implements SurfaceHolder.Callback,
     private float cachedFocusRatio = 0.5f;
     
     // isMenuEditing thin proxy removed — use menuController.isEditingMode()
-    private MenuController menuController;
     
     private GridLinesView gridLines;
     private CinemaMatteView cinemaMattes;
@@ -550,8 +549,7 @@ public void onEnterPressed() {
         if (calibController.handleUp()) return;
 
         if (menuController.isOpen()) { menuController.handleUp(); return; }
-            navigateHomeSpatial(ScalarInput.ISV_KEY_UP);
-        }
+        navigateHomeSpatial(ScalarInput.ISV_KEY_UP);
     }
 
     @Override
@@ -575,8 +573,7 @@ public void onEnterPressed() {
         if (calibController.handleDown()) return;
 
         if (menuController.isOpen()) { menuController.handleDown(); return; }
-            navigateHomeSpatial(ScalarInput.ISV_KEY_DOWN);
-        }
+        navigateHomeSpatial(ScalarInput.ISV_KEY_DOWN);
     }
 
     @Override
@@ -613,7 +610,9 @@ public void onEnterPressed() {
         if (hudController.isActive() && !menuController.isNamingMode()) { hudController.handleRight(); return; }
         if (isProcessing) return;
         if (calibController.handleRight()) return;
-        if (menuController.isOpen()) { menuController.handleRight(); return; } (!playbackController.isActive() && mDialMode == DIAL_MODE_FOCUS && lensManager != null && lensManager.isCurrentProfileManual()) {
+        if (menuController.isOpen()) { menuController.handleRight(); return; } 
+        
+        if (!playbackController.isActive() && mDialMode == DIAL_MODE_FOCUS && lensManager != null && lensManager.isCurrentProfileManual()) {
             virtualFocusRatio = Math.min(1.0f, virtualFocusRatio + 0.02f);
             if (focusMeter != null) focusMeter.update(virtualFocusRatio, virtualAperture, lensManager.getCurrentFocalLength(), false, lensManager.getCurrentPoints(), getCircleOfConfusion());
         } else if (playbackController.isActive()) {

--- a/app/src/main/java/com/github/ma1co/pmcademo/app/MainActivity.java
+++ b/app/src/main/java/com/github/ma1co/pmcademo/app/MainActivity.java
@@ -1510,7 +1510,7 @@ public void onEnterPressed() {
     }
 
     // --- PlaybackController.HostCallback ---
-    @Override public View getMainUIContainer() { return mainUIContainer; }
+    @Override public FrameLayout getMainUIContainer() { return mainUIContainer; }
     @Override public int getDisplayState()      { return displayState; }
 
     // --- LensCalibrationController.HostCallback ---


### PR DESCRIPTION
## What broke and why

During the Phase 5 god-class extraction, the Python regex replacement for `hudSelection` corrupted `} else if (hudSelection == X) {` conditions into `} else if (hudController.setSelection(X) {` — invalid Java. James caught and fixed the compiler errors.

However the deeper runtime issue was that the entire **calibration d-pad routing was dropped** during the refactor. In `master`, the input handlers have a critical chain:

```java
// onUpPressed (master):
if (isProcessing || waitingForProfileChoice) return;
if (isCalibrating) { ... handle calib step ... return; }
if (isMenuOpen) { ... }
else { navigateHomeSpatial(...) }
```

After the refactor, the correct equivalent through `calibController` was:

```java
// onUpPressed (refactored — correct):
if (isProcessing || calibController.isWaiting()) return;
if (calibController.handleUp()) return;
if (menuController.isOpen()) { menuController.handleUp(); return; }
navigateHomeSpatial(...)
```

But the refactored code was missing the `calibController.handleUp/Down/Left/Right/handleDial` delegation entirely — so all calibration d-pad logic was silently dropped, causing general d-pad misbehaviour on the camera.

## What James fixed in manual-adjust

- Added `calibController.handleUp/Down/Left/Right/handleDial()` delegation in each input handler
- Restored `calibController.isWaiting()` guard in `onUpPressed`  
- Added `calibController.handleDial(d)` in `onControlWheelRotated`
- Fixed the broken `setSelection(X) {` compiler errors from the Python replacement

## Root cause lesson

The Python mass-replacement approach (`hudSelection = X` → `hudController.setSelection(X)`) was too broad — it corrupted conditional expressions. Manual surgical edits per occurrence would have been safer for this kind of transformation.